### PR TITLE
fix: set audio resampler parameter to str

### DIFF
--- a/simli/utils.py
+++ b/simli/utils.py
@@ -3,7 +3,7 @@ import base64
 import av
 import numpy as np
 
-audioResampler = av.AudioResampler(format="s16", layout=1, rate=16000)
+audioResampler = av.AudioResampler(format="s16", layout="mono", rate=16000)
 
 
 def load_audio_file(filePath: str) -> bytes:


### PR DESCRIPTION
Newer versions of `av` package don't allow setting `layout` parameter of `AudioResampler` as int. This PR sets such value as `str`.

The fix is compatible with previous versions which take both `str` and `int`